### PR TITLE
Add devops-extra plugin

### DIFF
--- a/DIFF_2025-06-17_044758.md
+++ b/DIFF_2025-06-17_044758.md
@@ -1,0 +1,103 @@
+diff --git a/plugins/devops-extra/README.md b/plugins/devops-extra/README.md
+new file mode 100644
+index 00000000..a4db21b2
+--- /dev/null
++++ b/plugins/devops-extra/README.md
+@@ -0,0 +1,14 @@
++# devops-extra plugin
++
++This plugin provides a set of helper functions useful for DevOps workflows.
++
++## Features
++- `fuzzy_find`: fuzzy search files and directories using **fzf**.
++- `gpt_complete`: call the OpenAI API for quick code or text completion.
++- `git_repo`: lightweight git repository management helper.
++- `scaffold_from_tree`: create files and directories from indented tree text.
++- `clone_all_github_repos`: clone all repositories for a GitHub user via **gh** CLI.
++- Aliases for `uvx` and `e2b` executables.
++- `pg_start`: start a PostgreSQL cluster using `pg_ctlcluster`.
++
++Dependencies for some commands include `fzf`, `gh`, `jq`, and a valid `OPENAI_API_KEY` for API access.
+diff --git a/plugins/devops-extra/devops-extra.plugin.zsh b/plugins/devops-extra/devops-extra.plugin.zsh
+new file mode 100644
+index 00000000..d1c76523
+--- /dev/null
++++ b/plugins/devops-extra/devops-extra.plugin.zsh
+@@ -0,0 +1,77 @@
++# DevOps Extra plugin for Oh My Zsh
++# Provides utility functions and aliases for DevOps workflows.
++
++# Ensure dependencies
++command -v fzf >/dev/null 2>&1 || echo "[devops-extra] fzf not found. Install for fuzzy search." >&2
++
++# fuzzy_find - uses fzf to locate files or directories
++fuzzy_find() {
++  local target
++  target=$(find . -type f -o -type d 2>/dev/null | fzf --height 40% --reverse)
++  [[ -n $target ]] && print -- "$target"
++}
++
++# gpt_complete - call OpenAI API for code or text completion
++# Requires OPENAI_API_KEY environment variable
++# Usage: gpt_complete "prompt"
++gpt_complete() {
++  local prompt="$1"
++  if [[ -z $OPENAI_API_KEY ]]; then
++    echo "OPENAI_API_KEY not set" >&2
++    return 1
++  fi
++  curl -s https://api.openai.com/v1/completions \
++    -H "Content-Type: application/json" \
++    -H "Authorization: Bearer $OPENAI_API_KEY" \
++    -d '{"model":"text-davinci-003","prompt":"'$prompt'","max_tokens":64}' | jq -r '.choices[0].text'
++}
++
++# git_repo - manage git repositories quickly
++# Usage: git_repo init|clone|addremote <args>
++
++git_repo() {
++  case "$1" in
++    init)
++      git init && echo "Initialized git repository";;
++    clone)
++      git clone "$2";;
++    addremote)
++      git remote add origin "$2";;
++    *)
++      echo "Usage: git_repo {init|clone <url>|addremote <url>}";;
++  esac
++}
++
++# scaffold_from_tree - create files and dirs from tree-like text
++# Example input:
++# dir1/
++#   file1
++#   subdir/
++#     file2
++scaffold_from_tree() {
++  local line indent path stack=()
++  while IFS= read -r line; do
++    indent="${line%%[^ ]*}" # leading spaces
++    line="${line## }"       # trim leading spaces
++    if [[ $line == */ ]]; then
++      mkdir -p "$line"
++      stack+=("$line")
++    else
++      mkdir -p "${stack[-1]:-.}"
++      touch "${stack[-1]:-.}/$line"
++    fi
++  done
++}
++
++# clone_all_github_repos - requires gh CLI and GitHub auth
++clone_all_github_repos() {
++  gh repo list "$1" --limit 1000 --json sshUrl -q '.[].sshUrl' | xargs -n1 git clone
++}
++
++# quick aliases
++alias uvx='uvx'
++alias e2b='e2b'
++
++# Database helpers
++pg_start() { pg_ctlcluster "$1" start; }
++

--- a/RECOMMENDATIONS_2025-06-17_044758.md
+++ b/RECOMMENDATIONS_2025-06-17_044758.md
@@ -1,0 +1,3 @@
+- Consider adding unit tests for the new `devops-extra` plugin to ensure functions work as expected.
+- `scaffold_from_tree` currently assumes indentation with spaces; support for tabs may be beneficial.
+- Provide completions for the new commands using the completion system for better usability.

--- a/plugins/devops-extra/README.md
+++ b/plugins/devops-extra/README.md
@@ -1,0 +1,14 @@
+# devops-extra plugin
+
+This plugin provides a set of helper functions useful for DevOps workflows.
+
+## Features
+- `fuzzy_find`: fuzzy search files and directories using **fzf**.
+- `gpt_complete`: call the OpenAI API for quick code or text completion.
+- `git_repo`: lightweight git repository management helper.
+- `scaffold_from_tree`: create files and directories from indented tree text.
+- `clone_all_github_repos`: clone all repositories for a GitHub user via **gh** CLI.
+- Aliases for `uvx` and `e2b` executables.
+- `pg_start`: start a PostgreSQL cluster using `pg_ctlcluster`.
+
+Dependencies for some commands include `fzf`, `gh`, `jq`, and a valid `OPENAI_API_KEY` for API access.

--- a/plugins/devops-extra/devops-extra.plugin.zsh
+++ b/plugins/devops-extra/devops-extra.plugin.zsh
@@ -1,0 +1,77 @@
+# DevOps Extra plugin for Oh My Zsh
+# Provides utility functions and aliases for DevOps workflows.
+
+# Ensure dependencies
+command -v fzf >/dev/null 2>&1 || echo "[devops-extra] fzf not found. Install for fuzzy search." >&2
+
+# fuzzy_find - uses fzf to locate files or directories
+fuzzy_find() {
+  local target
+  target=$(find . -type f -o -type d 2>/dev/null | fzf --height 40% --reverse)
+  [[ -n $target ]] && print -- "$target"
+}
+
+# gpt_complete - call OpenAI API for code or text completion
+# Requires OPENAI_API_KEY environment variable
+# Usage: gpt_complete "prompt"
+gpt_complete() {
+  local prompt="$1"
+  if [[ -z $OPENAI_API_KEY ]]; then
+    echo "OPENAI_API_KEY not set" >&2
+    return 1
+  fi
+  curl -s https://api.openai.com/v1/completions \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -d '{"model":"text-davinci-003","prompt":"'$prompt'","max_tokens":64}' | jq -r '.choices[0].text'
+}
+
+# git_repo - manage git repositories quickly
+# Usage: git_repo init|clone|addremote <args>
+
+git_repo() {
+  case "$1" in
+    init)
+      git init && echo "Initialized git repository";;
+    clone)
+      git clone "$2";;
+    addremote)
+      git remote add origin "$2";;
+    *)
+      echo "Usage: git_repo {init|clone <url>|addremote <url>}";;
+  esac
+}
+
+# scaffold_from_tree - create files and dirs from tree-like text
+# Example input:
+# dir1/
+#   file1
+#   subdir/
+#     file2
+scaffold_from_tree() {
+  local line indent path stack=()
+  while IFS= read -r line; do
+    indent="${line%%[^ ]*}" # leading spaces
+    line="${line## }"       # trim leading spaces
+    if [[ $line == */ ]]; then
+      mkdir -p "$line"
+      stack+=("$line")
+    else
+      mkdir -p "${stack[-1]:-.}"
+      touch "${stack[-1]:-.}/$line"
+    fi
+  done
+}
+
+# clone_all_github_repos - requires gh CLI and GitHub auth
+clone_all_github_repos() {
+  gh repo list "$1" --limit 1000 --json sshUrl -q '.[].sshUrl' | xargs -n1 git clone
+}
+
+# quick aliases
+alias uvx='uvx'
+alias e2b='e2b'
+
+# Database helpers
+pg_start() { pg_ctlcluster "$1" start; }
+


### PR DESCRIPTION
## Summary
- add devops-extra plugin with fuzzy file search, git helper, scaffolding, github repo cloning, and AI completion
- document plugin features
- record diff and recommendations

## Testing
- `zsh lib/tests/cli.test.zsh`


------
https://chatgpt.com/codex/tasks/task_e_6850f31952e8832a8b19f2cb382cc600

## Summary by Sourcery

Introduce the new devops-extra Oh My Zsh plugin to streamline common DevOps workflows with fuzzy search, AI completion, git helpers, scaffolding, bulk repo cloning, and database management.

New Features:
- Add fuzzy file and directory search using fzf
- Enable AI-driven code and text completion via gpt_complete leveraging OpenAI API
- Provide lightweight git repository management commands (init, clone, addremote)
- Support scaffolding files and directories from indented tree text
- Allow bulk cloning of all GitHub repositories for a user via clone_all_github_repos
- Include a helper to start PostgreSQL clusters with pg_start
- Introduce quick command aliases for uvx and e2b

Documentation:
- Document plugin installation and usage in a new README.md

Chores:
- Add a developer recommendations file suggesting tests, indentation support, and completion integrations