### PR TITLE
Add deployment tools and SQL/AI plugin

### DIFF
--- a/CHEZMOI.md
+++ b/CHEZMOI.md
@@ -1,0 +1,12 @@
+# Deploying with chezmoi
+
+This repository can be managed as a dotfiles source with
+[chezmoi](https://www.chezmoi.io). The `tools/chezmoi-install.sh`
+script initializes chezmoi pointing at this directory and applies
+all configuration files.
+
+You can customize the installation using the YAML file in `config/`.
+Run:
+```bash
+./tools/chezmoi-install.sh
+```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,22 @@
+# Deployment Guide
+
+This guide provides steps to deploy Oh My Zsh across various
+systems using chezmoi.
+
+1. Install `chezmoi` from <https://www.chezmoi.io/get>.
+2. Clone or download this repository.
+3. Run `./tools/chezmoi-install.sh` to initialize chezmoi and apply files.
+4. Optionally edit `config/example-config.yaml` to customize plugins
+   and settings before applying.
+
+Chezmoi keeps your dotfiles under version control and can sync
+changes across multiple machines. After editing your dotfiles,
+run `chezmoi apply` to update them on the current device, and
+use git to push changes to share with others.
+
+### Using Other Shells
+
+The configuration is optimized for Zsh, but you can source the
+plugin scripts manually from other shells if needed. The YAML
+configuration can include a `shell` key to indicate which shell
+is targeted.

--- a/DIFF_2025-07-09_060358.md
+++ b/DIFF_2025-07-09_060358.md
@@ -1,0 +1,225 @@
+diff --git a/CHEZMOI.md b/CHEZMOI.md
+new file mode 100644
+index 00000000..c7ab1f80
+--- /dev/null
++++ b/CHEZMOI.md
+@@ -0,0 +1,12 @@
++# Deploying with chezmoi
++
++This repository can be managed as a dotfiles source with
++[chezmoi](https://www.chezmoi.io). The `tools/chezmoi-install.sh`
++script initializes chezmoi pointing at this directory and applies
++all configuration files.
++
++You can customize the installation using the YAML file in `config/`.
++Run:
++```bash
++./tools/chezmoi-install.sh
++```
+diff --git a/DEPLOYMENT.md b/DEPLOYMENT.md
+new file mode 100644
+index 00000000..241840b0
+--- /dev/null
++++ b/DEPLOYMENT.md
+@@ -0,0 +1,22 @@
++# Deployment Guide
++
++This guide provides steps to deploy Oh My Zsh across various
++systems using chezmoi.
++
++1. Install `chezmoi` from <https://www.chezmoi.io/get>.
++2. Clone or download this repository.
++3. Run `./tools/chezmoi-install.sh` to initialize chezmoi and apply files.
++4. Optionally edit `config/example-config.yaml` to customize plugins
++   and settings before applying.
++
++Chezmoi keeps your dotfiles under version control and can sync
++changes across multiple machines. After editing your dotfiles,
++run `chezmoi apply` to update them on the current device, and
++use git to push changes to share with others.
++
++### Using Other Shells
++
++The configuration is optimized for Zsh, but you can source the
++plugin scripts manually from other shells if needed. The YAML
++configuration can include a `shell` key to indicate which shell
++is targeted.
+diff --git a/FUNCTIONS.md b/FUNCTIONS.md
+new file mode 100644
+index 00000000..64008ddc
+--- /dev/null
++++ b/FUNCTIONS.md
+@@ -0,0 +1,31 @@
++# Functions Overview
++
++This document explains the purpose of the additional functions
++included with the custom plugins and scripts in this repository.
++
++## sql-ai plugin
++
++### sql_query
++Runs a SQL statement against a specified SQLite database.
++Example:
++```shell
++sql_query my.db "SELECT * FROM users;"
++```
++
++### ollama_chat
++Uses `ollama` to run a prompt through a local language model.
++Example:
++```shell
++ollama_chat "Explain Oh My Zsh"
++```
++
++## devops-extra plugin
++See `plugins/devops-extra/README.md` for the list of helper
++functions such as `fuzzy_find` and `gpt_complete`.
++
++## run_tests.sh
++Validates the syntax of core scripts, plugins and themes using
++`zsh -n`.
++
++## chezmoi-install.sh
++Sets up Oh My Zsh with chezmoi to sync your dotfiles across devices.
+diff --git a/README.md b/README.md
+index f7455228..d73007bd 100644
+--- a/README.md
++++ b/README.md
+@@ -536,6 +536,14 @@ Thank you so much!
+   <img src="https://contrib.rocks/image?repo=ohmyzsh/ohmyzsh" width="100%"/>
+ </a>
+ 
++## Additional Tools
++
++- **chezmoi-install.sh**: one-click deployment using chezmoi.
++- **run_tests.sh**: validate plugin and theme syntax.
++- **sql-ai plugin**: SQL and AI helpers powered by Ollama.
++- **ai-agents/**: sample agents utilizing Ollama.
++
++
+ ## Follow Us
+ 
+ We're on social media:
+diff --git a/ai-agents/README.md b/ai-agents/README.md
+new file mode 100644
+index 00000000..b0004f40
+--- /dev/null
++++ b/ai-agents/README.md
+@@ -0,0 +1,10 @@
++# AI Agents Repository
++
++This directory contains example agents powered by [Ollama](https://ollama.ai).
++Each agent is defined as a small shell script or configuration file that
++leverages the `ollama` command-line interface.
++
++Example usage:
++```
++./chat.sh "Write a haiku about the terminal"
++```
+diff --git a/ai-agents/chat.sh b/ai-agents/chat.sh
+new file mode 100755
+index 00000000..313c2251
+--- /dev/null
++++ b/ai-agents/chat.sh
+@@ -0,0 +1,3 @@
++#!/bin/sh
++# Simple AI chat script using Ollama
++ollama run "$@"
+diff --git a/config/example-config.yaml b/config/example-config.yaml
+new file mode 100644
+index 00000000..5346f9bc
+--- /dev/null
++++ b/config/example-config.yaml
+@@ -0,0 +1,7 @@
++# Example configuration for Oh My Zsh deployment
++shell: zsh
++os: linux
++plugins:
++  - git
++  - sql-ai
++  - devops-extra
+diff --git a/plugins/sql-ai/README.md b/plugins/sql-ai/README.md
+new file mode 100644
+index 00000000..aad4289f
+--- /dev/null
++++ b/plugins/sql-ai/README.md
+@@ -0,0 +1,10 @@
++# sql-ai plugin
++
++This plugin offers utility functions integrating SQL database queries
++and AI-powered chat commands via [Ollama](https://ollama.ai).
++
++## Features
++- `sql_query`: run a SQL query against a SQLite database.
++- `ollama_chat`: chat with a local Ollama model from the command line.
++
++The plugin assumes that `sqlite3` and the `ollama` CLI are installed.
+diff --git a/plugins/sql-ai/sql-ai.plugin.zsh b/plugins/sql-ai/sql-ai.plugin.zsh
+new file mode 100644
+index 00000000..be086661
+--- /dev/null
++++ b/plugins/sql-ai/sql-ai.plugin.zsh
+@@ -0,0 +1,28 @@
++# sql-ai plugin: SQL helpers and AI chat using Ollama
++
++# sql_query <database> <SQL>
++# Runs the given SQL query on the SQLite database.
++sql_query() {
++  local db="$1"; shift
++  local query="$@"
++  if [[ -z $db || -z $query ]]; then
++    echo "Usage: sql_query <db> <SQL>" >&2
++    return 1
++  fi
++  sqlite3 "$db" "$query"
++}
++
++# ollama_chat <prompt>
++# Sends a prompt to the local Ollama LLM and prints the response.
++ollama_chat() {
++  if ! command -v ollama >/dev/null; then
++    echo "ollama command not found" >&2
++    return 1
++  fi
++  local prompt="$*"
++  if [[ -z $prompt ]]; then
++    echo "Usage: ollama_chat <prompt>" >&2
++    return 1
++  fi
++  ollama run "$prompt"
++}
+diff --git a/tools/chezmoi-install.sh b/tools/chezmoi-install.sh
+new file mode 100755
+index 00000000..b8316529
+--- /dev/null
++++ b/tools/chezmoi-install.sh
+@@ -0,0 +1,8 @@
++#!/bin/sh
++# Install Oh My Zsh configuration using chezmoi
++if ! command -v chezmoi >/dev/null; then
++  echo "chezmoi is required: https://www.chezmoi.io/get" >&2
++  exit 1
++fi
++# init from repo and apply
++chezmoi init --source="$(pwd)" && chezmoi apply
+diff --git a/tools/run_tests.sh b/tools/run_tests.sh
+new file mode 100755
+index 00000000..37b8461b
+--- /dev/null
++++ b/tools/run_tests.sh
+@@ -0,0 +1,15 @@
++#!/bin/sh
++# Basic validation script for Oh My Zsh
++# Checks syntax of zsh plugins and themes
++
++if ! command -v zsh >/dev/null; then
++  echo "zsh is required to run tests" >&2
++  exit 1
++fi
++
++set -e
++for file in ./oh-my-zsh.sh ./lib/*.zsh ./plugins/*/*.plugin.zsh ./plugins/*/_* ./themes/*.zsh-theme; do
++  zsh -n "$file"
++done
++
++echo "Syntax check passed"

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -1,0 +1,31 @@
+# Functions Overview
+
+This document explains the purpose of the additional functions
+included with the custom plugins and scripts in this repository.
+
+## sql-ai plugin
+
+### sql_query
+Runs a SQL statement against a specified SQLite database.
+Example:
+```shell
+sql_query my.db "SELECT * FROM users;"
+```
+
+### ollama_chat
+Uses `ollama` to run a prompt through a local language model.
+Example:
+```shell
+ollama_chat "Explain Oh My Zsh"
+```
+
+## devops-extra plugin
+See `plugins/devops-extra/README.md` for the list of helper
+functions such as `fuzzy_find` and `gpt_complete`.
+
+## run_tests.sh
+Validates the syntax of core scripts, plugins and themes using
+`zsh -n`.
+
+## chezmoi-install.sh
+Sets up Oh My Zsh with chezmoi to sync your dotfiles across devices.

--- a/README.md
+++ b/README.md
@@ -536,6 +536,14 @@ Thank you so much!
   <img src="https://contrib.rocks/image?repo=ohmyzsh/ohmyzsh" width="100%"/>
 </a>
 
+## Additional Tools
+
+- **chezmoi-install.sh**: one-click deployment using chezmoi.
+- **run_tests.sh**: validate plugin and theme syntax.
+- **sql-ai plugin**: SQL and AI helpers powered by Ollama.
+- **ai-agents/**: sample agents utilizing Ollama.
+
+
 ## Follow Us
 
 We're on social media:

--- a/RECOMMENDATIONS_2025-07-09_060358.md
+++ b/RECOMMENDATIONS_2025-07-09_060358.md
@@ -1,0 +1,3 @@
+- Consider expanding tests to cover plugin functions with zunit.
+- Add CI job to run `tools/run_tests.sh` automatically.
+- Provide additional YAML examples for macOS and Windows shells.

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -1,0 +1,10 @@
+# AI Agents Repository
+
+This directory contains example agents powered by [Ollama](https://ollama.ai).
+Each agent is defined as a small shell script or configuration file that
+leverages the `ollama` command-line interface.
+
+Example usage:
+```
+./chat.sh "Write a haiku about the terminal"
+```

--- a/ai-agents/chat.sh
+++ b/ai-agents/chat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Simple AI chat script using Ollama
+ollama run "$@"

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -1,0 +1,7 @@
+# Example configuration for Oh My Zsh deployment
+shell: zsh
+os: linux
+plugins:
+  - git
+  - sql-ai
+  - devops-extra

--- a/plugins/sql-ai/README.md
+++ b/plugins/sql-ai/README.md
@@ -1,0 +1,10 @@
+# sql-ai plugin
+
+This plugin offers utility functions integrating SQL database queries
+and AI-powered chat commands via [Ollama](https://ollama.ai).
+
+## Features
+- `sql_query`: run a SQL query against a SQLite database.
+- `ollama_chat`: chat with a local Ollama model from the command line.
+
+The plugin assumes that `sqlite3` and the `ollama` CLI are installed.

--- a/plugins/sql-ai/sql-ai.plugin.zsh
+++ b/plugins/sql-ai/sql-ai.plugin.zsh
@@ -1,0 +1,28 @@
+# sql-ai plugin: SQL helpers and AI chat using Ollama
+
+# sql_query <database> <SQL>
+# Runs the given SQL query on the SQLite database.
+sql_query() {
+  local db="$1"; shift
+  local query="$@"
+  if [[ -z $db || -z $query ]]; then
+    echo "Usage: sql_query <db> <SQL>" >&2
+    return 1
+  fi
+  sqlite3 "$db" "$query"
+}
+
+# ollama_chat <prompt>
+# Sends a prompt to the local Ollama LLM and prints the response.
+ollama_chat() {
+  if ! command -v ollama >/dev/null; then
+    echo "ollama command not found" >&2
+    return 1
+  fi
+  local prompt="$*"
+  if [[ -z $prompt ]]; then
+    echo "Usage: ollama_chat <prompt>" >&2
+    return 1
+  fi
+  ollama run "$prompt"
+}

--- a/tools/chezmoi-install.sh
+++ b/tools/chezmoi-install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Install Oh My Zsh configuration using chezmoi
+if ! command -v chezmoi >/dev/null; then
+  echo "chezmoi is required: https://www.chezmoi.io/get" >&2
+  exit 1
+fi
+# init from repo and apply
+chezmoi init --source="$(pwd)" && chezmoi apply

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Basic validation script for Oh My Zsh
+# Checks syntax of zsh plugins and themes
+
+if ! command -v zsh >/dev/null; then
+  echo "zsh is required to run tests" >&2
+  exit 1
+fi
+
+set -e
+for file in ./oh-my-zsh.sh ./lib/*.zsh ./plugins/*/*.plugin.zsh ./plugins/*/_* ./themes/*.zsh-theme; do
+  zsh -n "$file"
+done
+
+echo "Syntax check passed"


### PR DESCRIPTION
## Summary
- add `sql-ai` plugin with SQL and Ollama helpers
- include `ai-agents` examples directory
- provide chezmoi installer and test runner
- add example YAML configuration
- document functions and deployment steps

## Testing
- `bash -c './tools/run_tests.sh'`

------
https://chatgpt.com/codex/tasks/task_e_686e05498bac832a9cbbe7cfad9c4d25

## Summary by Sourcery

Add a new SQL/AI plugin and sample Ollama-based agents, introduce one-click chezmoi deployment and syntax validation script, include example YAML configuration, and update documentation to cover the new tools and workflows.

New Features:
- Add sql-ai plugin offering `sql_query` and `ollama_chat` commands
- Introduce ai-agents directory with example Ollama-powered agent scripts

Deployment:
- Add tools/chezmoi-install.sh and `config/example-config.yaml` to automate dotfiles deployment via chezmoi

Documentation:
- Add CHEZMOI.md, DEPLOYMENT.md, FUNCTIONS.md, and plugin/ai-agents READMEs
- Update main README to list and describe the new tools and workflows

Tests:
- Add tools/run_tests.sh to validate zsh syntax across plugins, themes, and scripts